### PR TITLE
feat: 일정 관리 기능 구현 및 방문 인증 연동

### DIFF
--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/ItineraryController.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/ItineraryController.java
@@ -1,0 +1,76 @@
+package kr.ac.hs.RandomTrip.trip.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ac.hs.RandomTrip.auth.security.CustomUser;
+import kr.ac.hs.RandomTrip.trip.dto.itinerary.*;
+import kr.ac.hs.RandomTrip.trip.service.ItineraryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/itineraries")
+@RequiredArgsConstructor
+@Tag(name = "Itinerary", description = "일정 관리 API")
+public class ItineraryController {
+
+    private final ItineraryService itineraryService;
+
+    @PostMapping
+    @Operation(summary = "새 일정 생성")
+    public ResponseEntity<ItineraryResponseDto> createItinerary(Authentication authentication, @RequestBody ItineraryRequestDto requestDto) {
+        String username = getUsername(authentication);
+        ItineraryResponseDto responseDto = itineraryService.createItinerary(username, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @GetMapping
+    @Operation(summary = "내 모든 일정 조회")
+    public ResponseEntity<List<ItineraryResponseDto>> getAllItineraries(Authentication authentication) {
+        String username = getUsername(authentication);
+        List<ItineraryResponseDto> itineraries = itineraryService.getAllItineraries(username);
+        return ResponseEntity.ok(itineraries);
+    }
+
+    @GetMapping("/{itineraryId}")
+    @Operation(summary = "특정 일정 상세 조회")
+    public ResponseEntity<ItineraryDetailResponseDto> getItineraryDetails(Authentication authentication, @PathVariable Long itineraryId) {
+        String username = getUsername(authentication);
+        ItineraryDetailResponseDto itineraryDetails = itineraryService.getItineraryDetails(username, itineraryId);
+        return ResponseEntity.ok(itineraryDetails);
+    }
+
+    @PostMapping("/{itineraryId}/items")
+    @Operation(summary = "일정에 장소 추가")
+    public ResponseEntity<ItineraryItemResponseDto> addItemToItinerary(Authentication authentication, @PathVariable Long itineraryId, @RequestBody ItineraryItemRequestDto requestDto) {
+        String username = getUsername(authentication);
+        ItineraryItemResponseDto responseDto = itineraryService.addItemToItinerary(username, itineraryId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @DeleteMapping("/items/{itemId}")
+    @Operation(summary = "일정에서 장소 삭제")
+    public ResponseEntity<Void> removeItemFromItinerary(Authentication authentication, @PathVariable Long itemId) {
+        String username = getUsername(authentication);
+        itineraryService.removeItemFromItinerary(username, itemId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{itineraryId}/items/order")
+    @Operation(summary = "일정 내 장소 순서 변경")
+    public ResponseEntity<Void> updateItemOrder(Authentication authentication, @PathVariable Long itineraryId, @RequestBody ItineraryItemOrderRequestDto requestDto) {
+        String username = getUsername(authentication);
+        itineraryService.updateItemOrder(username, itineraryId, requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    private String getUsername(Authentication authentication) {
+        CustomUser user = (CustomUser) authentication.getPrincipal();
+        return user.getUsername();
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/Itinerary.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/Itinerary.java
@@ -1,0 +1,37 @@
+package kr.ac.hs.RandomTrip.trip.domain;
+
+import jakarta.persistence.*;
+import kr.ac.hs.RandomTrip.auth.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Itinerary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "itinerary", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("itemOrder ASC")
+    private List<ItineraryItem> items = new ArrayList<>();
+
+    @Builder
+    public Itinerary(String name, Member member) {
+        this.name = name;
+        this.member = member;
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/ItineraryItem.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/ItineraryItem.java
@@ -1,0 +1,36 @@
+package kr.ac.hs.RandomTrip.trip.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class ItineraryItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itinerary_id")
+    private Itinerary itinerary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "destination_id")
+    private Destination destination;
+
+    private int itemOrder;
+
+    private boolean visited = false;
+
+    @Builder
+    public ItineraryItem(Itinerary itinerary, Destination destination, int itemOrder) {
+        this.itinerary = itinerary;
+        this.destination = destination;
+        this.itemOrder = itemOrder;
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/TripResponse.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/TripResponse.java
@@ -41,4 +41,18 @@ public class TripResponse {
                         String areaCode, String contentTypeId, String mapy, String mapx) {
         this(null, title, address, imageUrl, description, areaCode, contentTypeId, mapy, mapx, null);
     }
+
+    // Destination 엔티티를 TripResponse DTO로 변환하는 생성자
+    public TripResponse(kr.ac.hs.RandomTrip.trip.domain.Destination destination) {
+        this.id = destination.getId();
+        this.title = destination.getTitle();
+        this.address = destination.getAddress();
+        this.imageUrl = destination.getImageUrl();
+        this.description = destination.getDescription();
+        this.areaCode = destination.getAreaCode();
+        this.contentTypeId = destination.getContentTypeId();
+        this.mapy = destination.getMapy();
+        this.mapx = destination.getMapx();
+        this.festivalPeriod = destination.getFestivalPeriod();
+    }
 }

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryDetailResponseDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryDetailResponseDto.java
@@ -1,0 +1,22 @@
+package kr.ac.hs.RandomTrip.trip.dto.itinerary;
+
+import kr.ac.hs.RandomTrip.trip.domain.Itinerary;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ItineraryDetailResponseDto {
+    private final Long id;
+    private final String name;
+    private final List<ItineraryItemResponseDto> items;
+
+    public ItineraryDetailResponseDto(Itinerary itinerary) {
+        this.id = itinerary.getId();
+        this.name = itinerary.getName();
+        this.items = itinerary.getItems().stream()
+                .map(ItineraryItemResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemOrderRequestDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemOrderRequestDto.java
@@ -1,0 +1,12 @@
+package kr.ac.hs.RandomTrip.trip.dto.itinerary;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ItineraryItemOrderRequestDto {
+    private List<Long> itemIds;
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemRequestDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemRequestDto.java
@@ -1,0 +1,10 @@
+package kr.ac.hs.RandomTrip.trip.dto.itinerary;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ItineraryItemRequestDto {
+    private Long destinationId;
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemResponseDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemResponseDto.java
@@ -1,0 +1,20 @@
+package kr.ac.hs.RandomTrip.trip.dto.itinerary;
+
+import kr.ac.hs.RandomTrip.trip.domain.ItineraryItem;
+import kr.ac.hs.RandomTrip.trip.dto.TripResponse;
+import lombok.Getter;
+
+@Getter
+public class ItineraryItemResponseDto {
+    private final Long id;
+    private final int itemOrder;
+    private final boolean visited;
+    private final TripResponse destination;
+
+    public ItineraryItemResponseDto(ItineraryItem itineraryItem) {
+        this.id = itineraryItem.getId();
+        this.itemOrder = itineraryItem.getItemOrder();
+        this.visited = itineraryItem.isVisited();
+        this.destination = new TripResponse(itineraryItem.getDestination());
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryRequestDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryRequestDto.java
@@ -1,0 +1,10 @@
+package kr.ac.hs.RandomTrip.trip.dto.itinerary;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ItineraryRequestDto {
+    private String name;
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryResponseDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryResponseDto.java
@@ -1,0 +1,15 @@
+package kr.ac.hs.RandomTrip.trip.dto.itinerary;
+
+import kr.ac.hs.RandomTrip.trip.domain.Itinerary;
+import lombok.Getter;
+
+@Getter
+public class ItineraryResponseDto {
+    private final Long id;
+    private final String name;
+
+    public ItineraryResponseDto(Itinerary itinerary) {
+        this.id = itinerary.getId();
+        this.name = itinerary.getName();
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/repository/ItineraryItemRepository.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/repository/ItineraryItemRepository.java
@@ -1,0 +1,11 @@
+package kr.ac.hs.RandomTrip.trip.repository;
+
+import kr.ac.hs.RandomTrip.trip.domain.ItineraryItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface ItineraryItemRepository extends JpaRepository<ItineraryItem, Long> {
+    Optional<ItineraryItem> findByIdAndItinerary_Member_Username(Long id, String username);
+    List<ItineraryItem> findByDestination_IdAndItinerary_Member_Username(Long destinationId, String username);
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/repository/ItineraryRepository.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/repository/ItineraryRepository.java
@@ -1,0 +1,11 @@
+package kr.ac.hs.RandomTrip.trip.repository;
+
+import kr.ac.hs.RandomTrip.trip.domain.Itinerary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
+    List<Itinerary> findByMember_Username(String username);
+    Optional<Itinerary> findByIdAndMember_Username(Long id, String username);
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/ItineraryService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/ItineraryService.java
@@ -1,0 +1,97 @@
+package kr.ac.hs.RandomTrip.trip.service;
+
+import kr.ac.hs.RandomTrip.auth.domain.Member;
+import kr.ac.hs.RandomTrip.auth.repository.MemberRepository;
+import kr.ac.hs.RandomTrip.trip.domain.Destination;
+import kr.ac.hs.RandomTrip.trip.domain.Itinerary;
+import kr.ac.hs.RandomTrip.trip.domain.ItineraryItem;
+import kr.ac.hs.RandomTrip.trip.dto.itinerary.*;
+import kr.ac.hs.RandomTrip.trip.repository.DestinationRepository;
+import kr.ac.hs.RandomTrip.trip.repository.ItineraryItemRepository;
+import kr.ac.hs.RandomTrip.trip.repository.ItineraryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ItineraryService {
+
+    private final ItineraryRepository itineraryRepository;
+    private final ItineraryItemRepository itineraryItemRepository;
+    private final MemberRepository memberRepository;
+    private final DestinationRepository destinationRepository;
+
+    public ItineraryResponseDto createItinerary(String username, ItineraryRequestDto requestDto) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+        Itinerary itinerary = Itinerary.builder()
+                .name(requestDto.getName())
+                .member(member)
+                .build();
+        Itinerary savedItinerary = itineraryRepository.save(itinerary);
+        return new ItineraryResponseDto(savedItinerary);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ItineraryResponseDto> getAllItineraries(String username) {
+        return itineraryRepository.findByMember_Username(username).stream()
+                .map(ItineraryResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ItineraryDetailResponseDto getItineraryDetails(String username, Long itineraryId) {
+        Itinerary itinerary = itineraryRepository.findByIdAndMember_Username(itineraryId, username)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다."));
+        return new ItineraryDetailResponseDto(itinerary);
+    }
+
+    public ItineraryItemResponseDto addItemToItinerary(String username, Long itineraryId, ItineraryItemRequestDto requestDto) {
+        Itinerary itinerary = itineraryRepository.findByIdAndMember_Username(itineraryId, username)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다."));
+        Destination destination = destinationRepository.findById(requestDto.getDestinationId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 장소를 찾을 수 없습니다."));
+
+        int order = itinerary.getItems().size() + 1;
+        ItineraryItem newItem = ItineraryItem.builder()
+                .itinerary(itinerary)
+                .destination(destination)
+                .itemOrder(order)
+                .build();
+
+        itinerary.getItems().add(newItem);
+        itineraryItemRepository.save(newItem);
+
+        return new ItineraryItemResponseDto(newItem);
+    }
+
+    public void removeItemFromItinerary(String username, Long itemId) {
+        ItineraryItem item = itineraryItemRepository.findByIdAndItinerary_Member_Username(itemId, username)
+                .orElseThrow(() -> new IllegalArgumentException("해당 항목을 찾을 수 없습니다."));
+        itineraryItemRepository.delete(item);
+    }
+
+    public void updateItemOrder(String username, Long itineraryId, ItineraryItemOrderRequestDto requestDto) {
+        Itinerary itinerary = itineraryRepository.findByIdAndMember_Username(itineraryId, username)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다."));
+
+        List<Long> itemIds = requestDto.getItemIds();
+        for (int i = 0; i < itemIds.size(); i++) {
+            Long itemId = itemIds.get(i);
+            int newOrder = i + 1;
+
+            ItineraryItem item = itinerary.getItems().stream()
+                    .filter(it -> it.getId().equals(itemId))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("일정에서 해당 항목을 찾을 수 없습니다: " + itemId));
+
+            item.setItemOrder(newOrder);
+        }
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/TourService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/TourService.java
@@ -6,6 +6,8 @@ import kr.ac.hs.RandomTrip.trip.domain.Destination;
 import kr.ac.hs.RandomTrip.trip.domain.Visit;
 import kr.ac.hs.RandomTrip.trip.dto.GuideResponse;
 import kr.ac.hs.RandomTrip.trip.repository.DestinationRepository;
+import kr.ac.hs.RandomTrip.trip.domain.ItineraryItem;
+import kr.ac.hs.RandomTrip.trip.repository.ItineraryItemRepository;
 import kr.ac.hs.RandomTrip.trip.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,8 +25,9 @@ public class TourService {
     private final VisitRepository visitRepository;
     private final MemberRepository memberRepository;
     private final GeminiGuideGenerator guideGenerator;
+    private final ItineraryItemRepository itineraryItemRepository;
 
-    private static final double MAX_DISTANCE_METERS = 100.0; // 100미터
+    private static final double MAX_DISTANCE_METERS = 500.0; // 500미터
 
     @Transactional(readOnly = true)
     public Optional<GuideResponse> getGuideForCurrentLocation(double lat, double lon) {
@@ -56,13 +59,19 @@ public class TourService {
 
         if (distance <= MAX_DISTANCE_METERS) {
             String username = SecurityContextHolder.getContext().getAuthentication().getName();
-            Optional<Member> memberOpt = memberRepository.findByUsername(username);
-            if (memberOpt.isEmpty()) {
-                // 로그인한 사용자를 찾을 수 없는 경우
-                return false;
-            }
-            Visit visit = new Visit(memberOpt.get(), destination);
+            Member member = memberRepository.findByUsername(username)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+
+            // 기존 Visit 기록 저장
+            Visit visit = new Visit(member, destination);
             visitRepository.save(visit);
+
+            // 일정 항목(ItineraryItem)의 방문 상태 업데이트
+            List<ItineraryItem> itemsToUpdate = itineraryItemRepository.findByDestination_IdAndItinerary_Member_Username(destinationId, username);
+            for (ItineraryItem item : itemsToUpdate) {
+                item.setVisited(true);
+            }
+
             return true;
         } else {
             return false;


### PR DESCRIPTION
새로운 일정 관리 시스템을 도입하여 사용자가 다음을 수행할 수 있도록 함:
- 개인 여행 일정 생성, 조회 및 관리
- 일정에 장소 추가 및 삭제
- 일정 내 장소 순서 변경
- verify api를 개선하여 성공적인 인증 시 해당 일정 항목의 방문 상태("visited")를 자동으로 업데이트