### PR TITLE
feat: 일정 관리 기능 추가 및 개선

### DIFF
--- a/backend/src/main/java/kr/ac/hs/RandomTrip/RandomTripApplication.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/RandomTripApplication.java
@@ -2,7 +2,9 @@ package kr.ac.hs.RandomTrip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class RandomTripApplication {
 

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/ItineraryController.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/ItineraryController.java
@@ -61,6 +61,22 @@ public class ItineraryController {
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("/{itineraryId}")
+    @Operation(summary = "일정 삭제")
+    public ResponseEntity<Void> deleteItinerary(Authentication authentication, @PathVariable Long itineraryId) {
+        String username = getUsername(authentication);
+        itineraryService.deleteItinerary(username, itineraryId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{itineraryId}")
+    @Operation(summary = "일정 이름 변경")
+    public ResponseEntity<ItineraryResponseDto> updateItinerary(Authentication authentication, @PathVariable Long itineraryId, @RequestBody ItineraryRequestDto requestDto) {
+        String username = getUsername(authentication);
+        ItineraryResponseDto responseDto = itineraryService.updateItinerary(username, itineraryId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
     @PutMapping("/{itineraryId}/items/order")
     @Operation(summary = "일정 내 장소 순서 변경")
     public ResponseEntity<Void> updateItemOrder(Authentication authentication, @PathVariable Long itineraryId, @RequestBody ItineraryItemOrderRequestDto requestDto) {

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/Itinerary.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/Itinerary.java
@@ -6,7 +6,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,12 +17,17 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Itinerary {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryDetailResponseDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryDetailResponseDto.java
@@ -1,8 +1,10 @@
 package kr.ac.hs.RandomTrip.trip.dto.itinerary;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import kr.ac.hs.RandomTrip.trip.domain.Itinerary;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,11 +12,16 @@ import java.util.stream.Collectors;
 public class ItineraryDetailResponseDto {
     private final Long id;
     private final String name;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime createdAt;
+    private final int itemCount;
     private final List<ItineraryItemResponseDto> items;
 
     public ItineraryDetailResponseDto(Itinerary itinerary) {
         this.id = itinerary.getId();
         this.name = itinerary.getName();
+        this.createdAt = itinerary.getCreatedAt();
+        this.itemCount = itinerary.getItems().size();
         this.items = itinerary.getItems().stream()
                 .map(ItineraryItemResponseDto::new)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryResponseDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryResponseDto.java
@@ -1,15 +1,23 @@
 package kr.ac.hs.RandomTrip.trip.dto.itinerary;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import kr.ac.hs.RandomTrip.trip.domain.Itinerary;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 public class ItineraryResponseDto {
     private final Long id;
     private final String name;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime createdAt;
+    private final int itemCount;
 
     public ItineraryResponseDto(Itinerary itinerary) {
         this.id = itinerary.getId();
         this.name = itinerary.getName();
+        this.createdAt = itinerary.getCreatedAt();
+        this.itemCount = itinerary.getItems().size();
     }
 }

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/ItineraryService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/ItineraryService.java
@@ -77,6 +77,20 @@ public class ItineraryService {
         itineraryItemRepository.delete(item);
     }
 
+    public void deleteItinerary(String username, Long itineraryId) {
+        Itinerary itinerary = itineraryRepository.findByIdAndMember_Username(itineraryId, username)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다."));
+        itineraryRepository.delete(itinerary);
+    }
+
+    public ItineraryResponseDto updateItinerary(String username, Long itineraryId, ItineraryRequestDto requestDto) {
+        Itinerary itinerary = itineraryRepository.findByIdAndMember_Username(itineraryId, username)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다."));
+        itinerary.setName(requestDto.getName());
+        Itinerary savedItinerary = itineraryRepository.save(itinerary);
+        return new ItineraryResponseDto(savedItinerary);
+    }
+
     public void updateItemOrder(String username, Long itineraryId, ItineraryItemOrderRequestDto requestDto) {
         Itinerary itinerary = itineraryRepository.findByIdAndMember_Username(itineraryId, username)
                 .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다."));


### PR DESCRIPTION
- 일정 삭제 기능 추가:
 DELETE /api/itineraries/{itineraryId} 엔드포인트를 통해 특정 일정을 삭제하는 기능을 구현
- 일정 이름 변경 기능 추가:
 PUT /api/itineraries/{itineraryId} 엔드포인트를 통해 일정의 이름을 변경할 수 있도록 구현
- 일정 정보 확장:
 모든 일정 조회 응답에 생성일(createdAt)과 포함된 장소의 수(itemCount)를 추가하여 더 상세한 정보를 제공하도록 개선