### PR TITLE
fix: CORS 설정 추가

### DIFF
--- a/backend/src/main/java/kr/ac/hs/RandomTrip/config/SecurityConfig.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/config/SecurityConfig.java
@@ -48,16 +48,14 @@ public class SecurityConfig {
                 .anyRequest().permitAll() // 나머지 요청은 일단 허용
         );
 
-        //        http.logout(logout -> logout.logoutUrl("/logout").logoutSuccessUrl("/"));
-
         return http.build();
     }
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:5173", "https://jolly-pebble-0b2668310.6.azurestaticapps.net", "https://randomtripapp-byd3gsg8bhh2f6cx.koreacentral-01.azurewebsites.net"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:5173", "https://jolly-pebble-0b2668310.6.azurestaticapps.net", "https://randomtripapp-byd3gsg8bhh2f6cx.koreacentral-01.azurewebsites.net"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/config/WebSocketConfig.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/config/WebSocketConfig.java
@@ -18,7 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-guide").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws-guide").setAllowedOriginPatterns("http://localhost:5173", "https://jolly-pebble-0b2668310.6.azurestaticapps.net", "https://randomtripapp-byd3gsg8bhh2f6cx.koreacentral-01.azurewebsites.net").withSockJS();
     }
 
 }


### PR DESCRIPTION
- CORS 설정 메소드 HEAD, PATCH 추가
- WebSockectConfig의 setAllowedOriginPatterns에 와일드카드 대신 프론트, 백엔드 주소를 추가하여 오류 방지