### PR TITLE
feat: '나만의 여행지도' 발자국 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.apache.commons:commons-text:1.10.0'
+	implementation 'com.azure:azure-storage-blob:12.25.1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/config/SecurityConfig.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/config/SecurityConfig.java
@@ -42,10 +42,24 @@ public class SecurityConfig {
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         http.authorizeHttpRequests((authorize) -> authorize
-                .requestMatchers("/", "/login", "/members", "/swagger-ui/**", "/v3/api-docs/**", "/api/hello", "/ws-guide/**").permitAll()
+                .requestMatchers("/",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/api/hello",
+                        "/api/trip/**",
+                        "/ws-guide/**",
+                        "/api/auth/login",
+                        "/api/auth/members").permitAll()
                 .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
-                .requestMatchers("/api/tour/**", "/my-page", "/api/auth/logout").hasRole("USER")
-                .anyRequest().permitAll() // 나머지 요청은 일단 허용
+                .requestMatchers(
+                        "/api/tour/**",
+                        "/api/itineraries/**",
+                        "/api/auth/my-page",
+                        "/api/auth/logout",
+                        "/api/footprints/**",
+                        "/api/storage/**").hasRole("USER")
+                .anyRequest().authenticated() // 나머지 요청은 인증된 사용자만 허용
+//                .anyRequest().permitAll() // 나머지 요청은 일단 허용
         );
 
         return http.build();

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/FootprintController.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/FootprintController.java
@@ -1,0 +1,60 @@
+package kr.ac.hs.RandomTrip.trip.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ac.hs.RandomTrip.auth.security.CustomUser;
+import kr.ac.hs.RandomTrip.trip.dto.footprint.FootprintRequestDto;
+import kr.ac.hs.RandomTrip.trip.dto.footprint.FootprintResponseDto;
+import kr.ac.hs.RandomTrip.trip.service.FootprintService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@Tag(name = "Footprint", description = "발자국 관련 API")
+@RestController
+@RequestMapping("/api/footprints")
+@RequiredArgsConstructor
+public class FootprintController {
+
+    private final FootprintService footprintService;
+
+    @Operation(summary = "내 발자국 목록 조회", description = "현재 로그인된 사용자의 모든 발자국 목록을 최신순으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<FootprintResponseDto>> getMyFootprints(
+            @AuthenticationPrincipal CustomUser customUser) {
+        List<FootprintResponseDto> myFootprints = footprintService.getMyFootprints(customUser.getUsername());
+        return ResponseEntity.ok(myFootprints);
+    }
+
+    @Operation(summary = "발자국 생성", description = "새로운 발자국을 생성하고, 생성된 리소스의 URI를 반환합니다.")
+    @PostMapping
+    public ResponseEntity<Void> createFootprint(
+            @RequestBody FootprintRequestDto requestDto,
+            @AuthenticationPrincipal CustomUser customUser) {
+        Long footprintId = footprintService.createFootprint(requestDto, customUser.getUsername());
+        return ResponseEntity.created(URI.create("/api/footprints/" + footprintId)).build();
+    }
+
+    @Operation(summary = "발자국 수정", description = "기존 발자국의 사진이나 메모를 수정합니다.")
+    @PutMapping("/{footprintId}")
+    public ResponseEntity<Void> updateFootprint(
+            @PathVariable Long footprintId,
+            @RequestBody FootprintRequestDto requestDto,
+            @AuthenticationPrincipal CustomUser customUser) {
+        footprintService.updateFootprint(footprintId, requestDto, customUser.getUsername());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "발자국 삭제", description = "특정 발자국을 삭제합니다.")
+    @DeleteMapping("/{footprintId}")
+    public ResponseEntity<Void> deleteFootprint(
+            @PathVariable Long footprintId,
+            @AuthenticationPrincipal CustomUser customUser) {
+        footprintService.deleteFootprint(footprintId, customUser.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/StorageController.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/StorageController.java
@@ -1,0 +1,39 @@
+package kr.ac.hs.RandomTrip.trip.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ac.hs.RandomTrip.trip.service.StorageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Tag(name = "Storage", description = "파일 스토리지 관련 API")
+@RestController
+@RequestMapping("/api/storage")
+@RequiredArgsConstructor
+public class StorageController {
+
+    private final StorageService storageService;
+
+    @Operation(summary = "업로드용 SAS URL 생성", description = "Azure Blob Storage에 파일을 업로드할 수 있는 임시 URL과 영구 URL을 생성합니다.")
+    @PostMapping("/sas-url")
+    public ResponseEntity<Map<String, String>> getSasUrl() {
+        String containerName = "footprint-images"; // Azure에 생성한 컨테이너 이름
+        String blobName = UUID.randomUUID().toString(); // 유니크한 파일 이름 생성
+
+        String sasUrl = storageService.generateSasUploadUrl(containerName, blobName);
+        String permanentUrl = storageService.getPermanentUrl(containerName, blobName);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("sasUrl", sasUrl); // 업로드에 사용할 임시 URL
+        response.put("permanentUrl", permanentUrl); // DB에 저장할 영구 URL
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/Footprint.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/domain/Footprint.java
@@ -1,0 +1,55 @@
+package kr.ac.hs.RandomTrip.trip.domain;
+
+import jakarta.persistence.*;
+import kr.ac.hs.RandomTrip.auth.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Footprint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "footprint_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "destination_id", nullable = false)
+    private Destination destination;
+
+    @Column(length = 500)
+    private String memo;
+
+    @Column(length = 2048)
+    private String photoUrl;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Footprint(Member member, Destination destination, String memo, String photoUrl) {
+        this.member = member;
+        this.destination = destination;
+        this.memo = memo;
+        this.photoUrl = photoUrl;
+    }
+
+    public void update(String memo, String photoUrl) {
+        this.memo = memo;
+        this.photoUrl = photoUrl;
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/footprint/FootprintRequestDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/footprint/FootprintRequestDto.java
@@ -1,0 +1,12 @@
+package kr.ac.hs.RandomTrip.trip.dto.footprint;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FootprintRequestDto {
+    private Long destinationId;
+    private String memo;
+    private String photoUrl;
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/footprint/FootprintResponseDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/footprint/FootprintResponseDto.java
@@ -1,0 +1,30 @@
+package kr.ac.hs.RandomTrip.trip.dto.footprint;
+
+import kr.ac.hs.RandomTrip.trip.domain.Footprint;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FootprintResponseDto {
+
+    private final Long id;
+    private final String memo;
+    private final String photoUrl;
+    private final LocalDateTime createdAt;
+    private final Long destinationId;
+    private final String destinationTitle;
+    private final String latitude; // from Destination.mapy
+    private final String longitude; // from Destination.mapx
+
+    public FootprintResponseDto(Footprint footprint) {
+        this.id = footprint.getId();
+        this.memo = footprint.getMemo();
+        this.photoUrl = footprint.getPhotoUrl();
+        this.createdAt = footprint.getCreatedAt();
+        this.destinationId = footprint.getDestination().getId();
+        this.destinationTitle = footprint.getDestination().getTitle();
+        this.latitude = footprint.getDestination().getMapy();
+        this.longitude = footprint.getDestination().getMapx();
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/repository/FootprintRepository.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/repository/FootprintRepository.java
@@ -1,0 +1,11 @@
+package kr.ac.hs.RandomTrip.trip.repository;
+
+import kr.ac.hs.RandomTrip.auth.domain.Member;
+import kr.ac.hs.RandomTrip.trip.domain.Footprint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FootprintRepository extends JpaRepository<Footprint, Long> {
+    List<Footprint> findAllByMemberOrderByCreatedAtDesc(Member member);
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/FootprintService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/FootprintService.java
@@ -1,0 +1,86 @@
+package kr.ac.hs.RandomTrip.trip.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import kr.ac.hs.RandomTrip.auth.domain.Member;
+import kr.ac.hs.RandomTrip.auth.repository.MemberRepository;
+import kr.ac.hs.RandomTrip.trip.domain.Destination;
+import kr.ac.hs.RandomTrip.trip.domain.Footprint;
+import kr.ac.hs.RandomTrip.trip.dto.footprint.FootprintRequestDto;
+import kr.ac.hs.RandomTrip.trip.dto.footprint.FootprintResponseDto;
+import kr.ac.hs.RandomTrip.trip.repository.DestinationRepository;
+import kr.ac.hs.RandomTrip.trip.repository.FootprintRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FootprintService {
+
+    private final FootprintRepository footprintRepository;
+    private final MemberRepository memberRepository;
+    private final DestinationRepository destinationRepository;
+
+    // 내 모든 발자국 조회
+    public List<FootprintResponseDto> getMyFootprints(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다. ID: " + username));
+
+        return footprintRepository.findAllByMemberOrderByCreatedAtDesc(member).stream()
+                .map(FootprintResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    // 발자국 생성
+    @Transactional
+    public Long createFootprint(FootprintRequestDto requestDto, String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다. ID: " + username));
+
+        Destination destination = destinationRepository.findById(requestDto.getDestinationId())
+                .orElseThrow(() -> new EntityNotFoundException("장소를 찾을 수 없습니다. ID: " + requestDto.getDestinationId()));
+
+        Footprint footprint = Footprint.builder()
+                .member(member)
+                .destination(destination)
+                .memo(requestDto.getMemo())
+                .photoUrl(requestDto.getPhotoUrl())
+                .build();
+
+        Footprint savedFootprint = footprintRepository.save(footprint);
+        return savedFootprint.getId();
+    }
+
+    // 발자국 수정
+    @Transactional
+    public Long updateFootprint(Long footprintId, FootprintRequestDto requestDto, String username) {
+        Footprint footprint = footprintRepository.findById(footprintId)
+                .orElseThrow(() -> new EntityNotFoundException("발자국을 찾을 수 없습니다. ID: " + footprintId));
+
+        // 권한 확인
+        if (!footprint.getMember().getUsername().equals(username)) {
+            throw new IllegalStateException("이 발자국을 수정할 권한이 없습니다.");
+        }
+
+        footprint.update(requestDto.getMemo(), requestDto.getPhotoUrl());
+        return footprint.getId();
+    }
+
+    // 발자국 삭제
+    @Transactional
+    public void deleteFootprint(Long footprintId, String username) {
+        Footprint footprint = footprintRepository.findById(footprintId)
+                .orElseThrow(() -> new EntityNotFoundException("발자국을 찾을 수 없습니다. ID: " + footprintId));
+
+        // 권한 확인
+        if (!footprint.getMember().getUsername().equals(username)) {
+            throw new IllegalStateException("이 발자국을 삭제할 권한이 없습니다.");
+        }
+
+        footprintRepository.delete(footprint);
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/StorageService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/StorageService.java
@@ -1,0 +1,51 @@
+package kr.ac.hs.RandomTrip.trip.service;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StorageService {
+
+    @Value("${azure.storage.connection-string}")
+    private String connectionString;
+
+    public String generateSasUploadUrl(String containerName, String blobName) {
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+                .connectionString(connectionString)
+                .buildClient();
+
+        BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(containerName);
+        BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+        // 5분 동안 유효한 쓰기 전용 SAS 토큰 생성
+        OffsetDateTime expiryTime = OffsetDateTime.now().plusMinutes(5);
+        BlobSasPermission permission = new BlobSasPermission()
+                .setWritePermission(true)
+                .setCreatePermission(true);
+        BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(expiryTime, permission);
+
+        // SAS 토큰이 포함된 전체 URL 반환
+        return String.format("%s?%s", blobClient.getBlobUrl(), blobClient.generateSas(values));
+    }
+    
+    public String getPermanentUrl(String containerName, String blobName) {
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+                .connectionString(connectionString)
+                .buildClient();
+        return String.format("https://%s.blob.core.windows.net/%s/%s", 
+            blobServiceClient.getAccountName(),
+            containerName, 
+            blobName);
+    }
+}


### PR DESCRIPTION
사용자가 방문한 장소에 사진과 메모를 남길 수 있는 '발자국' 기능을 구현.
사진 저장을 위해 Azure Blob Storage 연동 및 SAS URL 발급 기능을 추가.
- POST /api/footprints: 발자국 생성
- GET /api/footprints: 내 발자국 목록 조회
- PUT /api/footprints/{id}: 발자국 수정
- DELETE /api/footprints/{id}: 발자국 삭제
- POST /api/storage/sas-url: 업로드용 SAS URL 발급
- 신규 API 경로가 인증된 사용자만 접근할 수 있도록 보안 설정을 강화.
- Swagger API 문서화를 위한 어노테이션을 추가.
