### PR TITLE
gemini 가이드 추천 장소를 채팅에서 바로 일정에 추가할 수 있는 기능 구현

### DIFF
--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/GuideChatController.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/GuideChatController.java
@@ -23,15 +23,22 @@ public class GuideChatController {
         String destinationName = chatMessage.getDestinationName();
         String userMessage = chatMessage.getMessage();
 
-        // Gemini API를 호출하여 가이드 응답 생성
-        String guideResponse = geminiGuideGenerator.generateGuide(destinationName, userMessage);
+        // Gemini API를 호출하여 구조화된 가이드 응답 생성
+        GeminiGuideGenerator.GuideResponse guideResponse = geminiGuideGenerator.generateGuide(destinationName, userMessage);
 
         ChatMessage responseMessage = new ChatMessage();
-        responseMessage.setType(ChatMessage.MessageType.TALK);
         responseMessage.setSender("Gemini Guide");
         responseMessage.setReceiver(chatMessage.getSender());
-        responseMessage.setMessage(guideResponse);
         responseMessage.setDestinationName(destinationName);
+        responseMessage.setMessage(guideResponse.getReply());
+
+        // 장소 추천이 있는지 확인
+        if (guideResponse.getPlaceName() != null && !guideResponse.getPlaceName().isBlank()) {
+            responseMessage.setType(ChatMessage.MessageType.RECOMMEND);
+            responseMessage.setPlaceName(guideResponse.getPlaceName());
+        } else {
+            responseMessage.setType(ChatMessage.MessageType.TALK);
+        }
 
         messagingTemplate.convertAndSend(String.format("/topic/public/%s", destinationName), responseMessage);
     }
@@ -46,13 +53,13 @@ public class GuideChatController {
         headerAccessor.getSessionAttributes().put("destinationName", destinationName);
 
         // 초기 가이드 메시지 생성
-        String initialGuide = geminiGuideGenerator.generateGuide(destinationName);
+        GeminiGuideGenerator.GuideResponse initialGuide = geminiGuideGenerator.generateGuide(destinationName);
 
         ChatMessage initialMessage = new ChatMessage();
         initialMessage.setType(ChatMessage.MessageType.ENTER);
         initialMessage.setSender("Gemini Guide");
         initialMessage.setReceiver(username);
-        initialMessage.setMessage(initialGuide);
+        initialMessage.setMessage(initialGuide.getReply()); // 응답 객체의 reply 필드 사용
         initialMessage.setDestinationName(destinationName);
 
         messagingTemplate.convertAndSend(String.format("/topic/public/%s", destinationName), initialMessage);

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/ItineraryController.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/controller/ItineraryController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ac.hs.RandomTrip.auth.security.CustomUser;
 import kr.ac.hs.RandomTrip.trip.dto.itinerary.*;
 import kr.ac.hs.RandomTrip.trip.service.ItineraryService;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -46,10 +47,18 @@ public class ItineraryController {
     }
 
     @PostMapping("/{itineraryId}/items")
-    @Operation(summary = "일정에 장소 추가")
+    @Operation(summary = "일정에 장소 추가 (ID 사용)")
     public ResponseEntity<ItineraryItemResponseDto> addItemToItinerary(Authentication authentication, @PathVariable Long itineraryId, @RequestBody ItineraryItemRequestDto requestDto) {
         String username = getUsername(authentication);
         ItineraryItemResponseDto responseDto = itineraryService.addItemToItinerary(username, itineraryId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @PostMapping("/{itineraryId}/add-by-name")
+    @Operation(summary = "장소 이름으로 일정에 추가 (AI 가이드용)")
+    public ResponseEntity<ItineraryItemResponseDto> addItemByPlaceName(Authentication authentication, @PathVariable Long itineraryId, @RequestBody PlaceNameRequest request) {
+        String username = getUsername(authentication);
+        ItineraryItemResponseDto responseDto = itineraryService.addItemByPlaceName(username, itineraryId, request.getPlaceName());
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
@@ -96,5 +105,10 @@ public class ItineraryController {
     private String getUsername(Authentication authentication) {
         CustomUser user = (CustomUser) authentication.getPrincipal();
         return user.getUsername();
+    }
+
+    @Data
+    static class PlaceNameRequest {
+        private String placeName;
     }
 }

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/ChatMessage.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/ChatMessage.java
@@ -1,5 +1,6 @@
 package kr.ac.hs.RandomTrip.trip.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,9 +8,10 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 JSON 변환 시 제외
 public class ChatMessage {
     public enum MessageType {
-        ENTER, TALK, LEAVE
+        ENTER, TALK, LEAVE, RECOMMEND
     }
 
     private MessageType type;
@@ -17,4 +19,5 @@ public class ChatMessage {
     private String receiver;
     private String message;
     private String destinationName; // 목적지 이름 추가
+    private String placeName; // 추천 장소 이름
 }

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemRequestDto.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/dto/itinerary/ItineraryItemRequestDto.java
@@ -2,8 +2,10 @@ package kr.ac.hs.RandomTrip.trip.dto.itinerary;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class ItineraryItemRequestDto {
     private Long destinationId;

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/GeminiGuideGenerator.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/GeminiGuideGenerator.java
@@ -1,5 +1,6 @@
 package kr.ac.hs.RandomTrip.trip.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,100 +20,92 @@ import java.util.Optional;
 public class GeminiGuideGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(GeminiGuideGenerator.class);
-    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
+    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent";
 
     @Value("${gemini.api.key}")
     private String apiKey;
 
     private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public String generateGuide(String destinationName, String userMessage) {
-        String apiUrl = GEMINI_API_URL + "?key=" + apiKey;
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
+    public GuideResponse generateGuide(String destinationName, String userMessage) {
         String prompt = String.format(
-                "당신은 전문 여행 가이드입니다. 현재 '%s'에 대해 안내하고 있습니다. 사용자가 다음과 같이 질문했습니다: '%s'. 이 질문에 대해 3문장 이내로 간결하게 핵심만 답변해주세요. 답변은 한국어로 해주세요.",
+                "당신은 '%s'를 위한 전문 여행 가이드입니다. 사용자가 다음과 같이 질문했습니다: '%s'. " +
+                        "요청 내용을 분석한 뒤 아래 규칙에 따라 답변하세요. " +
+                        "1) 사용자가 특정 장소(예: 음식점, 카페, 명소 등)를 찾는 경우 → " +
+                        "{\"reply\": \"방문객에게 도움이 될 짧고 간결한 답변 (2~3문장 이내)\", \"placeName\": \"장소의 공식 명칭\"} 형식으로 답변합니다. " +
+                        "2) 일반적인 질문이거나 장소 추천이 필요 없는 경우 → " +
+                        "{\"reply\": \"간단하고 명확한 안내 (2~3문장 이내)\", \"placeName\": null} 형식으로 답변합니다. " +
+                        "답변은 항상 한국어로 작성하고, 장소 추천 시 반드시 하나의 장소만 제시하세요.",
                 destinationName, userMessage
         );
-
-        GeminiRequest requestBody = new GeminiRequest(
-                Collections.singletonList(new Content(Collections.singletonList(new Part(prompt))))
-        );
-
-        HttpEntity<GeminiRequest> entity = new HttpEntity<>(requestBody, headers);
-
-        try {
-            ResponseEntity<GeminiResponse> response = restTemplate.exchange(
-                    apiUrl,
-                    HttpMethod.POST,
-                    entity,
-                    GeminiResponse.class
-            );
-
-            String rawText = Optional.ofNullable(response.getBody())
-                    .flatMap(body -> body.getCandidates().stream().findFirst())
-                    .map(candidate -> candidate.getContent().getParts().get(0).getText())
-                    .orElse("죄송합니다, 답변을 생성할 수 없습니다.");
-            return formatGuideText(rawText);
-
-        } catch (RestClientException e) {
-            logger.error("Gemini API 호출 중 오류 발생: " + e.getMessage(), e);
-            return "죄송합니다, 지금은 답변할 수 없습니다. 잠시 후 다시 시도해주세요.";
-        }
+        return callGeminiApi(prompt);
     }
 
-    public String generateGuide(String destinationName) {
-        String apiUrl = GEMINI_API_URL + "?key=" + apiKey;
+    public GuideResponse generateGuide(String destinationName) {
+        String prompt = String.format(
+                "당신은 전문 여행 가이드입니다. '%s'에 대해 3문장 이내로 간결하게 소개해주세요. " +
+                        "설명에는 그 장소의 역사, 흥미로운 사실, 그리고 방문객에게 도움이 될 만한 실용적인 팁을 반드시 포함하세요. " +
+                        "항상 한국어로, 전문 가이드처럼 차분하고 정확하게 설명해야 합니다. " +
+                        "응답은 반드시 {\"reply\": \"소개 내용\", \"placeName\": null} 형식의 JSON으로 제공하세요.",
+                destinationName
+        );
+        return callGeminiApi(prompt);
+    }
 
+    private GuideResponse callGeminiApi(String prompt) {
+        String apiUrl = GEMINI_API_URL + "?key=" + apiKey;
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        String prompt = String.format(
-                "당신은 전문 여행 가이드입니다. '%s'에 대해 3문장 이내로 간결하게 핵심만 설명해주세요. 이 장소의 역사, 흥미로운 사실, 그리고 방문객을 위한 유용한 팁을 포함하여, 친절하고 매력적인 톤으로 설명해주세요. 답변은 한국어로 해주세요.",
-                destinationName
-        );
-
         GeminiRequest requestBody = new GeminiRequest(
                 Collections.singletonList(new Content(Collections.singletonList(new Part(prompt))))
         );
-
         HttpEntity<GeminiRequest> entity = new HttpEntity<>(requestBody, headers);
 
         try {
-            ResponseEntity<GeminiResponse> response = restTemplate.exchange(
-                    apiUrl,
-                    HttpMethod.POST,
-                    entity,
-                    GeminiResponse.class
+            ResponseEntity<GeminiApiResponse> response = restTemplate.exchange(
+                    apiUrl, HttpMethod.POST, entity, GeminiApiResponse.class
             );
 
-            String rawText = Optional.ofNullable(response.getBody())
+            String rawJson = Optional.ofNullable(response.getBody())
                     .flatMap(body -> body.getCandidates().stream().findFirst())
                     .map(candidate -> candidate.getContent().getParts().get(0).getText())
-                    .orElse("죄송합니다, 가이드 정보를 생성할 수 없습니다.");
-            return formatGuideText(rawText);
+                    .orElse("{\"reply\": \"죄송합니다, 답변을 생성할 수 없습니다.\", \"placeName\": null}");
 
-        } catch (RestClientException e) {
-            logger.error("Gemini API 호출 중 오류 발생: " + e.getMessage(), e);
-            return String.format("[임시 가이드] %s에 오신 것을 환영합니다! (API 호출 실패)", destinationName);
+            // Clean up the raw JSON string
+            rawJson = cleanJsonString(rawJson);
+
+            return objectMapper.readValue(rawJson, GuideResponse.class);
+
+        } catch (Exception e) {
+            logger.error("Error calling Gemini API or parsing response: " + e.getMessage(), e);
+            return new GuideResponse("죄송합니다, 지금은 답변할 수 없습니다. 잠시 후 다시 시도해주세요.", null);
         }
     }
-    
-    // 문장마다 들여쓰기 추가하는 메서드
-    private String formatGuideText(String text) {
-        if (text == null || text.trim().isEmpty()) {
-            return "";
+
+    private String cleanJsonString(String rawJson) {
+        // Remove markdown backticks for JSON block
+        String cleaned = rawJson.trim();
+        if (cleaned.startsWith("```json")) {
+            cleaned = cleaned.substring(7);
         }
-        // 문장 끝에 오는 점과 공백을 찾아 줄바꿈과 들여쓰기를 추가합니다.
-        return text.replace(". ", ".\n").trim();
+        if (cleaned.endsWith("```")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 3);
+        }
+        return cleaned.trim();
     }
 
-
+    // --- DTO Classes for this Service ---
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GuideResponse {
+        private String reply;
+        private String placeName;
+    }
 
     // --- DTO Classes for Gemini API ---
-
     @Data
     @AllArgsConstructor
     private static class GeminiRequest {
@@ -121,21 +114,21 @@ public class GeminiGuideGenerator {
 
     @Data
     @AllArgsConstructor
-    @NoArgsConstructor // 추가
+    @NoArgsConstructor
     private static class Content {
         private List<Part> parts;
     }
 
     @Data
     @AllArgsConstructor
-    @NoArgsConstructor // 추가
+    @NoArgsConstructor
     private static class Part {
         private String text;
     }
 
     @Data
     @NoArgsConstructor
-    private static class GeminiResponse {
+    private static class GeminiApiResponse {
         private List<Candidate> candidates;
     }
 

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/ItineraryService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/ItineraryService.java
@@ -28,6 +28,7 @@ public class ItineraryService {
     private final ItineraryItemRepository itineraryItemRepository;
     private final MemberRepository memberRepository;
     private final DestinationRepository destinationRepository;
+    private final TripService tripService; // TripService 주입
 
     public ItineraryResponseDto createItinerary(String username, ItineraryRequestDto requestDto) {
         Member member = memberRepository.findByUsername(username)
@@ -78,6 +79,17 @@ public class ItineraryService {
         itineraryItemRepository.save(newItem);
 
         return new ItineraryItemResponseDto(newItem);
+    }
+
+    // TripService의 하이브리드 검색 메소드를 사용하도록 수정한 메소드
+    public ItineraryItemResponseDto addItemByPlaceName(String username, Long itineraryId, String placeName) {
+        Destination destination = tripService.findTopDestinationByHybridSearch(placeName)
+                .orElseThrow(() -> new IllegalArgumentException("'" + placeName + "'에 대한 장소를 찾을 수 없습니다."));
+
+        ItineraryItemRequestDto requestDto = new ItineraryItemRequestDto();
+        requestDto.setDestinationId(destination.getId());
+        
+        return addItemToItinerary(username, itineraryId, requestDto);
     }
 
     public void removeItemFromItinerary(String username, Long itemId) {

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/TourService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/TourService.java
@@ -39,8 +39,9 @@ public class TourService {
         }
 
         if (closestDestination.getGuide() == null || closestDestination.getGuide().isBlank()) {
-            String guide = guideGenerator.generateGuide(closestDestination.getTitle());
-            closestDestination.setGuide(guide);
+            GeminiGuideGenerator.GuideResponse guideResponse = guideGenerator.generateGuide(closestDestination.getTitle());
+            String guideText = guideResponse.getReply(); // 응답 객체에서 실제 텍스트를 추출
+            closestDestination.setGuide(guideText);
             destinationRepository.save(closestDestination);
         }
 

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/TripService.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/trip/service/TripService.java
@@ -803,4 +803,32 @@ public class TripService {
         }
     }
 
+    @Transactional
+    public Optional<Destination> findTopDestinationByHybridSearch(String placeName) {
+        // 1. TourAPI 우선 검색
+        try {
+            JsonNode tourItems = tourApiClient.searchByKeyword(placeName, "", 1, new String[]{"12", "14", "25", "28"});
+            if (tourItems != null && tourItems.size() > 0) {
+                // TourAPI 결과가 있으면 첫 번째 아이템으로 Destination을 찾거나 생성
+                return Optional.ofNullable(findOrCreateDestinationFromTour(tourItems.get(0)));
+            }
+        } catch (Exception e) {
+            System.err.println("TourAPI search failed during hybrid search: " + e.getMessage());
+            // 에러 발생 시 KakaoAPI로 폴백(fallback)
+        }
+
+        // 2. TourAPI에 결과가 없으면 KakaoAPI 검색
+        try {
+            JsonNode kakaoPlaces = kakaoApiClient.searchPlaces(placeName, "");
+            if (kakaoPlaces != null && kakaoPlaces.size() > 0) {
+                // KakaoAPI 결과가 있으면 첫 번째 아이템으로 Destination을 찾거나 생성
+                return Optional.ofNullable(findOrCreateDestinationFromKakao(kakaoPlaces.get(0)));
+            }
+        } catch (Exception e) {
+            System.err.println("KakaoAPI search failed during hybrid search: " + e.getMessage());
+        }
+
+        return Optional.empty();
+    }
+
 }


### PR DESCRIPTION
변경 사항
- GeminiGuideGenerator: JSON 응답 구조 개선, 초기 프롬프트 수정
- ChatMessage: placeName 필드 및 RECOMMEND 타입 추가
- GuideChatController: placeName 유무에 따라 TALK/RECOMMEND 전송
- ItineraryService: addItemByPlaceName 메소드 추가
- ItineraryController: /api/itineraries/{itineraryId}/add-by-name 엔드포인트 추가

테스트
1. 서버 실행 후 채팅에서 장소 추천 질문 입력
2. WS 메시지에서 type=RECOMMEND, placeName 포함 여부 확인
3. Swagger로 일정 추가 API 동작 확인