### PR TITLE
test/aop: 여행 추천 및 Gemini 챗봇 API 테스트 추가 및 AOP 기반 성능 로깅 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.apache.commons:commons-text:1.10.0'
 	implementation 'com.azure:azure-storage-blob:12.25.1'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/aop/ApiPerformanceLogAspect.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/aop/ApiPerformanceLogAspect.java
@@ -1,0 +1,46 @@
+package kr.ac.hs.RandomTrip.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ApiPerformanceLogAspect {
+
+    // "performance.logger"라는 이름으로 로거를 생성합니다. 이 이름은 logback-spring.xml에서 사용됩니다.
+    private static final Logger performanceLogger = LoggerFactory.getLogger("performance.logger");
+
+    // kr.ac.hs.RandomTrip 패키지 내의 모든 Controller 클래스의 모든 public 메소드에 적용됩니다.
+    @Around("execution(* kr.ac.hs.RandomTrip..*Controller.*(..))")
+    public Object logApiPerformance(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        String methodName = joinPoint.getSignature().toShortString();
+        Object result;
+
+        try {
+            // 대상 API 메소드를 실행합니다.
+            result = joinPoint.proceed();
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+
+            // API가 성공적으로 실행되었을 때 로그를 기록합니다.
+            performanceLogger.info("[SUCCESS] Method: {} | Duration: {}ms", methodName, duration);
+
+        } catch (Throwable throwable) {
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+
+            // API 실행 중 예외가 발생했을 때 로그를 기록합니다.
+            performanceLogger.error("[FAILURE] Method: {} | Duration: {}ms | Error: {}", methodName, duration, throwable.getMessage());
+            
+            // 예외를 다시 던져서 Spring의 기본 예외 처리가 동작하도록 합니다.
+            throw throwable;
+        }
+
+        return result;
+    }
+}

--- a/backend/src/main/java/kr/ac/hs/RandomTrip/aop/ApiPerformanceLogAspect.java
+++ b/backend/src/main/java/kr/ac/hs/RandomTrip/aop/ApiPerformanceLogAspect.java
@@ -15,7 +15,7 @@ public class ApiPerformanceLogAspect {
     private static final Logger performanceLogger = LoggerFactory.getLogger("performance.logger");
 
     // kr.ac.hs.RandomTrip 패키지 내의 모든 Controller 클래스의 모든 public 메소드에 적용됩니다.
-    @Around("execution(* kr.ac.hs.RandomTrip..*Controller.*(..))")
+    @Around("execution(* kr.ac.hs.RandomTrip..*Controller.*(..)) || @annotation(org.springframework.messaging.handler.annotation.MessageMapping)")
     public Object logApiPerformance(ProceedingJoinPoint joinPoint) throws Throwable {
         long startTime = System.currentTimeMillis();
         String methodName = joinPoint.getSignature().toShortString();

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 콘솔 Appender 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 성능 로그 파일 Appender 설정 -->
+    <appender name="PERFORMANCE_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/performance.log</file> <!-- 로그 파일 경로 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 매일 새로운 로그 파일 생성 -->
+            <fileNamePattern>./logs/performance.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 30일간 로그 보관 -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <!-- 로그 포맷 -->
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 성능 로거 설정 -->
+    <!-- Aspect에서 "performance.logger"로 생성한 로거에 대한 설정입니다. -->
+    <logger name="performance.logger" level="INFO" additivity="false">
+        <appender-ref ref="PERFORMANCE_LOG" />
+    </logger>
+
+    <!-- 기본 Spring Boot 로거 설정 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/backend/src/test/java/kr/ac/hs/RandomTrip/guidechat/controller/GuideChatControllerTest.java
+++ b/backend/src/test/java/kr/ac/hs/RandomTrip/guidechat/controller/GuideChatControllerTest.java
@@ -1,0 +1,84 @@
+package kr.ac.hs.RandomTrip.guidechat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ac.hs.RandomTrip.guidechat.dto.ChatMessageDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GuideChatControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private WebSocketStompClient stompClient;
+
+    @BeforeEach
+    void setUp() {
+        List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+        SockJsClient sockJsClient = new SockJsClient(transports);
+        this.stompClient = new WebSocketStompClient(sockJsClient);
+        this.stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+    }
+
+    @DisplayName("가이드 챗봇 접속 및 실제 API 호출 20회 반복 테스트")
+    @RepeatedTest(20)
+    void addUser_and_getRealResponse_Repeated() throws Exception {
+        // given
+        String destinationName = "경복궁";
+        CompletableFuture<ChatMessageDto> completableFuture = new CompletableFuture<>();
+
+        // when
+        StompSession stompSession = stompClient.connectAsync(String.format("ws://localhost:%d/ws-guide", port), new StompSessionHandlerAdapter() {}).get(1, TimeUnit.SECONDS);
+
+        stompSession.subscribe(String.format("/topic/public/%s", destinationName), new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return ChatMessageDto.class;
+            }
+
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {
+                completableFuture.complete((ChatMessageDto) payload);
+            }
+        });
+
+        ChatMessageDto enterMessage = new ChatMessageDto();
+        enterMessage.setType(ChatMessageDto.MessageType.ENTER);
+        enterMessage.setSender("testUser");
+        enterMessage.setDestinationName(destinationName);
+        stompSession.send("/app/guide.addUser", enterMessage);
+
+        // then: 실제 API 응답이므로, null이 아니고 내용이 비어있지 않은지만 확인합니다.
+        ChatMessageDto receivedMessage = completableFuture.get(30, TimeUnit.SECONDS); // 외부 API 호출 시간을 고려해 대기 시간을 30초로 늘립니다.
+
+        assertThat(receivedMessage).isNotNull();
+        assertThat(receivedMessage.getType()).isEqualTo(ChatMessageDto.MessageType.ENTER);
+        assertThat(receivedMessage.getSender()).isEqualTo("Gemini Guide");
+        assertThat(receivedMessage.getMessage()).isNotNull().isNotEmpty();
+    }
+}

--- a/backend/src/test/java/kr/ac/hs/RandomTrip/trip/controller/TripControllerTest.java
+++ b/backend/src/test/java/kr/ac/hs/RandomTrip/trip/controller/TripControllerTest.java
@@ -1,0 +1,63 @@
+package kr.ac.hs.RandomTrip.trip.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ac.hs.RandomTrip.trip.dto.TripRecommendRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class TripControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("도보 여행 코스 추천 API 20회 반복 테스트")
+    @RepeatedTest(20)
+    void recommendTripWalk_Repeated() throws Exception {
+        // given: API에 보낼 요청 데이터를 준비합니다.
+        TripRecommendRequestDto requestDto = new TripRecommendRequestDto("인천에서 산책하기 좋은 곳");
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // when & then: API를 호출하고 결과를 검증합니다.
+        mockMvc.perform(post("/api/trip/recommend-walk") // 1. POST 요청을 /api/trip/recommend-walk 경로로 보냅니다.
+                        .contentType(MediaType.APPLICATION_JSON)      // 2. 요청 본문의 타입은 JSON입니다.
+                        .content(requestBody))                        // 3. 위에서 만든 JSON 데이터를 요청 본문에 담습니다.
+                .andExpect(status().isOk())                           // 4. 응답 상태 코드가 200 (OK)인지 확인합니다.
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON)) // 5. 응답 본문의 타입도 JSON인지 확인합니다.
+                .andDo(print());                                      // 6. 요청과 응답의 전체 내용을 콘솔에 출력합니다.
+    }
+
+    @DisplayName("차량 여행 코스 추천 API 20회 반복 테스트")
+    @RepeatedTest(20)
+    void recommendTripCar_Repeated() throws Exception {
+        // given
+        TripRecommendRequestDto requestDto = new TripRecommendRequestDto("부산에서 바다 보기 좋은 드라이브 코스");
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // when & then
+        mockMvc.perform(post("/api/trip/recommend-car")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
- 여행 추천(도보/차량) 및 가이드 챗봇 API의 테스트 코드 추가
- AOP를 활용한 API 성능 로깅 기능 구현
- logback 설정을 통해 성능 로그를 별도 파일(`performance.log`)로 관리하도록 개선

주요 변경 사항

1. TripControllerTest / GuideChatControllerTest
- /api/trip/recommend-walk, /api/trip/recommend-car 테스트 추가
  - MockMvc 기반 POST 요청 검증
  - JSON 응답 타입 및 상태 코드(200 OK) 확인
  - 20회 반복 실행으로 응답 일관성 확인 (`@RepeatedTest(20)`)
- `GuideChatControllerTest`
  - WebSocket 기반 `/ws-guide` 연결 및 메시지 송수신 검증
  - Gemini Guide 챗봇의 실제 응답 메시지 유효성 확인

2. ApiPerformanceLogAspect
- @Around 어드바이스를 이용해 모든 Controller 및 MessageMapping 메소드의 실행 시간을 측정
- 성공 시 [SUCCESS], 실패 시 [FAILURE] 로그 출력
- 예외 발생 시 로그 기록 후 재던짐 처리로 Spring 예외 흐름 유지

3. logback-spring.xml
- performance.logger 설정 추가
- ./logs/performance.log 파일로 성능 로그 기록
- 날짜별 로그 롤링 및 30일 보관 설정
